### PR TITLE
fix(safari): add locationHref to fix clipPath issues in safari

### DIFF
--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -45,6 +45,8 @@ export class LottieAnimationViewComponent implements OnInit {
         this.viewWidth = this.width + 'px' || '100%';
         this.viewHeight = this.height + 'px' || '100%';
 
+	lottie.setLocationHref(document.location.href);
+
         let anim: any = lottie.loadAnimation(this._options);
         this.animCreated.emit(anim);
     }


### PR DESCRIPTION
## Expected Behavior
When I use a lottie animation that has a clipPath with angular, I should expect the same results across browsers.

## Current Behavior
In safari, when using an animation that uses clipPath, the mask/clipPath won't apply due to the `<base href="/">` that is used by default in angular.

## Related issue
In github.com/airbnb/lottie-web - https://github.com/airbnb/lottie-web/issues/914

Fixes #36 

## Related PRs
https://github.com/airbnb/lottie-web/pull/382