### PR TITLE
fix: linting

### DIFF
--- a/src/lottieAnimationView.component.ts
+++ b/src/lottieAnimationView.component.ts
@@ -12,8 +12,6 @@ const lottie: any = require('lottie-web/build/player/lottie.js');
 })
 
 export class LottieAnimationViewComponent implements OnInit {
-    
-    constructor(@Inject(PLATFORM_ID) private platformId: string) {}
 
     @Input() options: any;
     @Input() width: number;
@@ -27,10 +25,12 @@ export class LottieAnimationViewComponent implements OnInit {
     public viewHeight: string;
     private _options: any;
 
+    constructor(@Inject(PLATFORM_ID) private platformId: string) {}
+
     ngOnInit() {
-        
-        if(isPlatformServer(this.platformId)){return;}
-        
+
+        if (isPlatformServer(this.platformId)) { return; }
+
         this._options = {
             container: this.lavContainer.nativeElement,
             renderer: this.options.renderer || 'svg',


### PR DESCRIPTION
Fixed linting as the current code base generates an error in the generated umd bundle saying:

```
const lottieAnimationView_component_1 = __webpack_require__(!(function webpackMissingModule() { var e = new Error("Cannot find module \"./lottieAnimationView.component\""); e.code = 'MODULE_NOT_FOUND'; throw e; }()));
```
On line 77